### PR TITLE
new: Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+on:
+  workflow_dispatch: null
+  release:
+    types: [ published ]
+jobs:
+  galaxyrelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+
+      - name: update packages
+        run: sudo apt-get update -y
+
+      - name: install make
+        run: sudo apt-get install -y build-essential
+
+      - name: setup python 3
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # pin@v2
+        with:
+          python-version: '3.x'
+
+      - name: build the package
+        run: make build
+        env:
+          SPECDOC_VERSION: ${{ github.event.release.tag_name }}
+
+      - name: publish the release to pypi
+        uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f # pin@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,11 @@ test:
 lint:
 	pylint ./tests ./ansible_specdoc
 
-build:
-	pip3 install -r requirements-dev.txt && python setup.py build && python -m build
+deps:
+	pip install -r requirements-dev.txt -r requirements.txt
+
+build: deps
+	python setup.py build && python -m build
 
 install: clean_dist build
 	pip3 install --force dist/*.whl

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,35 @@
+import os
+
 import setuptools
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+def get_long_description():
+    with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+        long_description = f.read()
+
+    return long_description
+
+def get_version():
+    version_env = os.getenv("SPECDOC_VERSION")
+
+    if version_env is not None:
+        return version_env.replace("v", "")
+
+    # Default unspecified version
+    return "0.0.0"
 
 setuptools.setup(
     name="ansible-specdoc",
-    version="0.0.10",
+    version=get_version(),
     author="Linode",
     author_email="dev-dx@linode.com",
-    description=("A simple tool for generating Ansible collection documentation from module spec."),
-    license="GNU General Public License v3.0",
+    description="A simple tool for generating Ansible collection documentation from module spec.",
+    long_description=get_long_description(),
+    long_description_content_type="text/markdown",
+    license="Apache License 2.0",
     keywords="ansible",
-    url="http://packages.python.org/ansible-specdoc",
+    url="https://github.com/linode/ansible-specdoc/",
     packages=['ansible_specdoc'],
     install_requires=[
         'PyYAML==5.4.1',


### PR DESCRIPTION
## 📝 Description

This change introduces a GitHub actions workflow for automatically publishing `ansible-specdoc` release to PyPI. Additionally, this change makes various corrections to the `setup.py` file.

Before a release can be cut, a `PYPI_API_TOKEN` secret scoped to the `ansible-specdoc` repo on PyPI must be created.

This change has been tested on a private repository and works as intended.
