### PR TITLE
new: Add `conflicts_with` field

### DIFF
--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -86,6 +86,7 @@ class SpecDocModule:
                 'type': param.get('type'),
                 'required': param.get('required') or False,
                 'editable': param.get('editable') or False,
+                'conflicts_with': param.get('conflicts_with') or False,
                 'description': [desc] if isinstance(desc, str) else desc
             }
 

--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -86,7 +86,7 @@ class SpecDocModule:
                 'type': param.get('type'),
                 'required': param.get('required') or False,
                 'editable': param.get('editable') or False,
-                'conflicts_with': param.get('conflicts_with') or False,
+                'conflicts_with': param.get('conflicts_with') or [],
                 'description': [desc] if isinstance(desc, str) else desc
             }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,9 +39,17 @@ class TestDocs(unittest.TestCase):
                 assert value.get('required') == (module_spec.get(key).get('required') or False)
                 assert value.get('description') == module_spec.get(key).get('description')
 
-                options: Optional[Dict[str, Any]] = value.get('suboptions')
+                options = value.get('suboptions')
                 if options is not None:
                     assert_spec_recursive(options, module_spec.get(key).get('options'))
+
+                editable = value.get('editable')
+                if editable:
+                    assert editable == module_spec.get(key).get('editable')
+
+                conflicts_with = value.get('conflicts_with')
+                if conflicts_with:
+                    assert conflicts_with == module_spec.get(key).get('conflicts_with')
 
         assert_spec_recursive(new_spec.get('options'), original_spec.get('spec'))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@
 import json
 import os
 import unittest
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 
 import yaml
 from ansible_specdoc.cli import SpecDocModule, CLI

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -8,10 +8,13 @@ my_module_dict_spec = {
     'my-int': {
         'type': 'int',
         'required': True,
+        'editable': True,
+        'conflicts_with': ['my-bool'],
         'description': ['A really cool required int']
     },
     'my-bool': {
         'type': 'bool',
+        'conflicts_with': ['my-int'],
         'description': [
             'A really cool bool that does stuff',
             'Here\'s another line :)'


### PR DESCRIPTION
## 📝 Description

This pull request adds an optional `conflicts_with` argument for spec fields. This field is "dumb" and does not currently auto-populate. 

## ✔️ How to Test

`make test`
