### PR TITLE
ref: (BREAKING) Rewrite to use classes and objects rather than dicts

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
 [MASTER]
 
 [MESSAGES CONTROL]
-disable=exec-used, too-many-branches, too-few-public-methods, unspecified-encoding, consider-using-f-string
+disable=exec-used, too-many-branches, too-few-public-methods, unspecified-encoding, consider-using-f-string, too-many-instance-attributes

--- a/README.md
+++ b/README.md
@@ -28,38 +28,43 @@ optional arguments:
 ## Specification Format
 
 ### Module Metadata
-The `ansible-specdoc` specification format requires that each module exports a `specdoc_meta` dict with the following structure:
+The `ansible-specdoc` specification format requires that each module exports a `SPECDOC_META` object with the following structure:
 
 ```python
-specdoc_meta = dict(
+SPECDOC_META = SpecDocMeta(
     description=['Module Description'],
     requirements=['python >= 3.6'],
     author=['Author Name'],
-    spec=module_spec,
+    options=module_spec,
     examples=[
         'example module usage'
     ],
-    return_values=dict(
-        my_return_value=dict(
+    return_values={
+        'my_return_value': SpecReturnValue(
             description='A generic return value.',
-            type='str',
+            type=FieldType.String,
             sample=['sample response']
         ),
-    )
+    }
 )
 ```
 
 ### Argument Specification
 
-The `spec` field of the `specdoc_meta` struct should refer to an
-[Ansible argument specification](https://docs.ansible.com/ansible/latest/dev_guide/developing_program_flow_modules.html#argument-spec).
+Certain fields may automatically be passed into the Ansible-compatible spec dict.
 
-Spec fields may contain an additional `description` field that will appear in the documentation.
+Spec fields may additional metadata that will appear in the documentation.
 
 For example:
 
 ```python
-module_spec = dict(
-    example_argument=dict(type='str', required=True, description='An example argument.')
-)
+module_spec = {
+    'example_argument': SpecField(
+        type=FieldType.String, 
+        required=True, 
+        description=['An example argument.']
+    )
+}
 ```
+
+In order to retrieve the Ansible-compatible spec dict, use the `SPECDOC_META.ansible_spec` property.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SPECDOC_META = SpecDocMeta(
     return_values={
         'my_return_value': SpecReturnValue(
             description='A generic return value.',
-            type=FieldType.String,
+            type=FieldType.string,
             sample=['sample response']
         ),
     }
@@ -60,8 +60,8 @@ For example:
 ```python
 module_spec = {
     'example_argument': SpecField(
-        type=FieldType.String, 
-        required=True, 
+        type=FieldType.string,
+        required=True,
         description=['An example argument.']
     )
 }

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -1,0 +1,148 @@
+"""
+This module contains various classes to be used in Ansible modules.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+
+
+class FieldType:
+    """
+    Enum for Ansible-compatible field types.
+    """
+
+    List = 'list'
+    Dict = 'dict'
+    Bool = 'bool'
+    Integer = 'int'
+    String = 'str'
+    Float = 'float'
+    Path = 'path'
+    Raw = 'raw'
+    JSONArg = 'jsonarg'
+    Json = 'json'
+    Bytes = 'bytes'
+    Bits = 'bits'
+
+
+@dataclass
+class SpecField:
+    """
+    A single field to be used in an Ansible module.
+    """
+
+    description: List[str]
+    type: FieldType
+
+    required: bool = False
+    default: Optional[Any] = None
+    editable: bool = False
+    conflicts_with: Optional[List[str]] = field(default_factory=lambda: [])
+    no_log: bool = False
+    choices: Optional[List[str]] = None
+    doc_hide: bool = False
+    aliases: Optional[List[str]] = None
+
+    # These fields are only necessary for `list` and `dict` types
+    element_type: Optional[FieldType] = None
+    suboptions: Optional[Dict[str, 'SpecField']] = None  # Forward-declared
+
+    # Additional fields to pass into the output Ansible spec dict
+    additional_fields: Optional[Dict[str, Any]] = None
+
+    @property
+    def doc_dict(self) -> Optional[Dict[str, Any]]:
+        """
+        Returns the docs dict for this field.
+        """
+
+        result = self.__dict__
+        if self.suboptions is not None:
+            result['suboptions'] = {
+                k: v.doc_dict for k, v in self.suboptions.items() if not v.doc_hide
+            }
+
+        return result
+
+
+    @property
+    def ansible_spec(self) -> Dict[str, Any]:
+        """
+        Returns the Ansible-compatible spec for this field.
+        """
+        result = {
+            'type': str(self.type),
+            'no_log': self.no_log,
+            'required': self.required,
+        }
+
+        if self.default is not None:
+            result['default'] = self.default
+
+        if self.choices is not None:
+            result['choices'] = self.choices
+
+        if self.aliases is not None:
+            result['aliases'] = self.aliases
+
+        if self.suboptions is not None:
+            result['options'] = {k: v.ansible_spec for k, v in self.suboptions.items()}
+
+        if self.element_type is not None:
+            result['elements'] = str(self.element_type)
+
+        if self.additional_fields is not None:
+            result = {**result, **self.additional_fields}
+
+        return result
+
+
+@dataclass
+class SpecReturnValue:
+    """
+    A description of an Ansible module's return value.
+    """
+    description: str
+    type: FieldType
+
+    sample: List[str] = field(default_factory=lambda: [])
+    docs_url: Optional[str] = None
+    elements: Optional[FieldType] = None
+
+@dataclass
+class SpecDocMeta:
+    """
+    The top-level description of an Ansible module.
+    """
+    description: List[str]
+    options: Dict[str, SpecField]
+
+    requirements: Optional[List[str]] = None
+    author: Optional[List[str]] = None
+    examples: Optional[List[str]] = field(default_factory=lambda: [])
+    return_values: Optional[Dict[str, SpecReturnValue]] = field(default_factory=lambda: {})
+
+    @property
+    def doc_dict(self) -> Dict[str, Any]:
+        """
+        Returns the documentation dict for this module.
+
+        This isn't implemented as __dict__ because it is not 1:1 with the class layout.
+        """
+
+        result = self.__dict__
+
+        result['options'] = {k: v.doc_dict for k, v in self.options.items() if not v.doc_hide}
+
+        if self.return_values is not None:
+            result['return_values'] = {k: v.__dict__ for k, v in self.return_values.items()}
+
+        return result
+
+    @property
+    def ansible_spec(self) -> Dict[str, Any]:
+        """
+        Returns the Ansible-compatible spec for this module.
+        """
+
+        return {k: v.ansible_spec for k, v in self.options.items()}

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -30,10 +30,9 @@ class SpecField:
     """
     A single field to be used in an Ansible module.
     """
-
-    description: List[str]
     type: FieldType
 
+    description: Optional[List[str]] = None
     required: bool = False
     default: Optional[Any] = None
     editable: bool = False

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -11,18 +11,18 @@ class FieldType:
     Enum for Ansible-compatible field types.
     """
 
-    List = 'list'
-    Dict = 'dict'
-    Bool = 'bool'
-    Integer = 'int'
-    String = 'str'
-    Float = 'float'
-    Path = 'path'
-    Raw = 'raw'
-    JSONArg = 'jsonarg'
-    Json = 'json'
-    Bytes = 'bytes'
-    Bits = 'bits'
+    list = 'list'
+    dict = 'dict'
+    bool = 'bool'
+    integer = 'int'
+    string = 'str'
+    float = 'float'
+    path = 'path'
+    raw = 'raw'
+    json_arg = 'jsonarg'
+    json = 'json'
+    bytes = 'bytes'
+    bits = 'bits'
 
 
 @dataclass

--- a/tests/test_modules/__init__.py
+++ b/tests/test_modules/__init__.py
@@ -1,3 +1,3 @@
 """Module containing Ansible modules used for testing"""
 
-from .module_1 import specdoc_meta
+from .module_1 import SPECDOC_META

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -1,62 +1,75 @@
 """Module for testing docs generation functionality"""
 
+from ansible_specdoc.objects import SpecDocMeta, SpecField, FieldType, SpecReturnValue
+
 DOCUMENTATION = '''
 really cool non-empty docstring
 '''
 
-my_module_dict_spec = {
-    'my-int': {
-        'type': 'int',
-        'required': True,
-        'editable': True,
-        'conflicts_with': ['my-bool'],
-        'description': ['A really cool required int']
-    },
-    'my-bool': {
-        'type': 'bool',
-        'conflicts_with': ['my-int'],
-        'description': [
+MY_MODULE_DICT_SPEC = {
+    'my-int': SpecField(
+        type=FieldType.Integer,
+        required=True,
+        editable=True,
+        conflicts_with=['my-bool'],
+        description=['A really cool required int']
+    ),
+    'my-bool': SpecField(
+        type=FieldType.Bool,
+        conflicts_with=['my-int'],
+        description=[
             'A really cool bool that does stuff',
             'Here\'s another line :)'
         ]
-    },
-    'my-hidden-var': {
-        'type': 'bool',
-        'description': [
+    ),
+    'my-hidden-var': SpecField(
+        type=FieldType.Bool,
+        description=[
             'dont show this!!!'
         ],
-        'doc_hide': True
-    }
+        doc_hide=True
+    )
 }
 
-my_module_spec = {
-    'my-string': {
-        'type': 'str',
-        'required': True,
-        'description': ['A really cool string that does stuff!']
-    },
-    'my-list': {
-        'type': 'list',
-        'elements': 'str',
-        'description': ['A really cool list of strings']
-    },
-    'my-dict': {
-        'type': 'dict',
-        'options': my_module_dict_spec,
-        'description': ['A really cool dict']
-    },
-
+MY_MODULE_SPEC = {
+    'my-string': SpecField(
+        type=FieldType.String,
+        required=True,
+        description=['A really cool string that does stuff!'],
+    ),
+    'my-list': SpecField(
+        type=FieldType.List,
+        element_type=FieldType.String,
+        description=['A really cool list of strings']
+    ),
+    'my-dict': SpecField(
+        type=FieldType.Dict,
+        suboptions=MY_MODULE_DICT_SPEC,
+        description=['A really cool dict']
+    )
 }
 
-specdoc_meta = {
-    'description': [
+SPECDOC_META = SpecDocMeta(
+    description=[
         'My really cool Ansible module!'
     ],
-    'requirements': [
+    requirements=[
         'python >= 3.8'
     ],
-    'author': [
+    author=[
         'Lena Garber'
     ],
-    'spec': my_module_spec
-}
+    examples=[
+        'blah'
+    ],
+    return_values={
+        'cool': SpecReturnValue(
+            description='COOL',
+            docs_url='http://localhost',
+            type=FieldType.List,
+            elements=FieldType.String,
+            sample=['["COOL"]'],
+        )
+    },
+    options=MY_MODULE_SPEC
+)

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -8,14 +8,14 @@ really cool non-empty docstring
 
 MY_MODULE_DICT_SPEC = {
     'my-int': SpecField(
-        type=FieldType.Integer,
+        type=FieldType.integer,
         required=True,
         editable=True,
         conflicts_with=['my-bool'],
         description=['A really cool required int']
     ),
     'my-bool': SpecField(
-        type=FieldType.Bool,
+        type=FieldType.bool,
         conflicts_with=['my-int'],
         description=[
             'A really cool bool that does stuff',
@@ -23,7 +23,7 @@ MY_MODULE_DICT_SPEC = {
         ]
     ),
     'my-hidden-var': SpecField(
-        type=FieldType.Bool,
+        type=FieldType.bool,
         description=[
             'dont show this!!!'
         ],
@@ -33,17 +33,17 @@ MY_MODULE_DICT_SPEC = {
 
 MY_MODULE_SPEC = {
     'my-string': SpecField(
-        type=FieldType.String,
+        type=FieldType.string,
         required=True,
         description=['A really cool string that does stuff!'],
     ),
     'my-list': SpecField(
-        type=FieldType.List,
-        element_type=FieldType.String,
+        type=FieldType.list,
+        element_type=FieldType.string,
         description=['A really cool list of strings']
     ),
     'my-dict': SpecField(
-        type=FieldType.Dict,
+        type=FieldType.dict,
         suboptions=MY_MODULE_DICT_SPEC,
         description=['A really cool dict']
     )
@@ -66,8 +66,8 @@ SPECDOC_META = SpecDocMeta(
         'cool': SpecReturnValue(
             description='COOL',
             docs_url='http://localhost',
-            type=FieldType.List,
-            elements=FieldType.String,
+            type=FieldType.list,
+            elements=FieldType.string,
             sample=['["COOL"]'],
         )
     },


### PR DESCRIPTION
## 📝 Description

**THIS IS A BREAKING CHANGE**

This change overhauls the user-implemented spec structure to use classes rather than raw dictionaries. This allows for improved static analysis and more control over which fields are passed to Ansible.

This change has been tested against `ansible_linode`.

## ✔️ How to Test

```
make test
```

## :heavy_check_mark: Example Usage

```python
spec_filter = dict(
    name=SpecField(type=FieldType.string, required=True,
              description=[
                  'The name of the field to filter on.',
                  'Valid filterable attributes can be found here: '
                  # pylint: disable-next=line-too-long
                  'https://www.linode.com/docs/api/stackscripts/#stackscripts-list__response-samples',
              ]),
    values=SpecField(type=FieldType.list, element_type=FieldType.string, required=True,
                description=[
                    'A list of values to allow for this field.',
                    'Fields will pass this filter if at least one of these values matches.'
                ])
)

spec = dict(
    # Disable the default values
    state=SpecField(type=FieldType.string, required=False, doc_hide=True),
    label=SpecField(type=FieldType.string, required=False, doc_hide=True),

    order=SpecField(
        type=FieldType.string,
        description=['The order to list events in.'],
        default='asc',
        choices=['desc', 'asc']
    ),
    order_by=SpecField(
        type=FieldType.string,
        description=['The attribute to order events by.']
    ),
    filters=SpecField(
        type=FieldType.list, element_type=FieldType.dict,
        suboptions=spec_filter,
        description=['A list of filters to apply to the resulting events.']
    ),
    count=SpecField(
        type=FieldType.integer,
        description=[
            'The number of results to return.',
            'If undefined, all results will be returned.'
        ])
)

SPECDOC_META = SpecDocMeta(
    description=[
        'List and filter on Linode stackscripts.'
    ],
    requirements=global_requirements,
    author=global_authors,
    options=spec,
    examples=docs.specdoc_examples,
    return_values=dict(
        stackscripts=SpecReturnValue(
            description='The returned stackscripts.',
            docs_url='https://www.linode.com/docs/api/stackscripts/'
                     '#stackscripts-list__response-samples',
            type=FieldType.list,
            elements=FieldType.dict,
            sample=docs.result_stackscripts_samples
        )
    )
)


class Module(LinodeModuleBase):
    """Module for getting a list of Linode stackscripts"""

    def __init__(self) -> None:
        self.module_arg_spec = SPECDOC_META.ansible_spec

...
```