### PR TITLE
fix: Enable `lstrip_blocks` for j2 templating

### DIFF
--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -129,7 +129,8 @@ class SpecDocModule:
     def generate_jinja2(self, tmpl_str: str) -> str:
         """Generates a text output from the given Jinja2 template"""
         env = jinja2.Environment(
-            trim_blocks=True
+            trim_blocks=True,
+            lstrip_blocks=True
         )
 
         template = env.from_string(tmpl_str)


### PR DESCRIPTION
## 📝 Description

This change enabled the `lstrip_blocks` j2 environment variable for better whitespace control.
