### PR TITLE
fix: Allow any type for `choices` field

### DIFF
--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -38,7 +38,7 @@ class SpecField:
     editable: bool = False
     conflicts_with: Optional[List[str]] = field(default_factory=lambda: [])
     no_log: bool = False
-    choices: Optional[List[str]] = None
+    choices: Optional[List[Any]] = None
     doc_hide: bool = False
     aliases: Optional[List[str]] = None
 

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -1,7 +1,7 @@
 """
 This module contains various classes to be used in Ansible modules.
 """
-
+import copy
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any
 
@@ -55,7 +55,7 @@ class SpecField:
         Returns the docs dict for this field.
         """
 
-        result = self.__dict__
+        result = copy.deepcopy(self.__dict__)
         if self.suboptions is not None:
             result['suboptions'] = {
                 k: v.doc_dict for k, v in self.suboptions.items() if not v.doc_hide


### PR DESCRIPTION
## 📝 Description

This change alters the `choices` field to allow any type rather than only strings.
