### PR TITLE
new: (BREAKING) Improve documentation injection logic and add support for additional constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Generating a raw documentation string (not recommended):
 ansible-specdoc -f yaml -i path/to/my/module.py
 ```
 
-## Specification Format
+## Implementation
 
 ### Module Metadata
 The `ansible-specdoc` specification format requires that each module exports a `SPECDOC_META` object with the following structure:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ansible-specdoc [-h] [-s] [-n MODULE_NAME] [-i INPUT_FILE] [-o OUTPUT_FILE] [-f 
 
 Generate Ansible Module documentation from spec.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   -s, --stdin           Read the module from stdin.
   -n MODULE_NAME, --module-name MODULE_NAME
@@ -22,7 +22,7 @@ optional arguments:
                         The file to output the documentation to.
   -f {yaml,json,jinja2}, --output_format {yaml,json,jinja2}
                         The output format of the documentation.
-  -j, --inject          Inject the output documentation into the `DOCUMENTATION` field of input module.
+  -j, --inject          Inject the output documentation into the `DOCUMENTATION`, `RETURN`, and `EXAMPLES` fields of input module.
   -t TEMPLATE_FILE, --template_file TEMPLATE_FILE
                         The file to use as the template for templated formats.
 ```

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ from ansible_specdoc.objects import *
 Alternatively, only specific classes can be imported using the following statement:
 
 ```python
-from ansible_specdoc.objects import SpecDocMeta, SpecField, SpecReturnValue, FieldType
+from ansible_specdoc.objects import SpecDocMeta, SpecField, SpecReturnValue, FieldType, DeprecationInfo
 ```
 
 ### Declaring Module Metadata
@@ -120,6 +120,24 @@ To prevent `ansible-specdoc` from executing module code, please ensure that all 
 if __name__ == '__main__':
     main()
 ```
+
+---
+
+To deprecate a module, specify the `deprecated` field as follows:
+
+```python
+SPECDOC_META = SpecDocMeta(
+    ...
+    deprecated=DeprecationInfo(
+        alternative='my.new.module',
+        removed_in='1.0.0',
+        why='Reason for deprecation'
+    )
+)
+```
+
+When deprecating a module, you will also need to update your `meta/runtime.yml` file.
+Please refer to the [official Ansible deprecation documentation](https://docs.ansible.com/ansible/latest/dev_guide/module_lifecycle.html#deprecating-modules-and-plugins-in-a-collection) for more details.
 
 ## Templates
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ansible-specdoc
 
-A utility for dynamically generating documentation from an Ansible module's spec. This is primarily designed for the [Linode Ansible Collection](https://github.com/linode/ansible_linode).
+A utility for dynamically generating documentation from an Ansible module's spec. 
+
+This project was primarily designed for the [Linode Ansible Collection](https://github.com/linode/ansible_linode).
 
 ## Usage
 
@@ -25,19 +27,27 @@ optional arguments:
                         The file to use as the template for templated formats.
 ```
 
-Generating a templated documentation file:
+---
+
+#### Generating a templated documentation file:
 
 ```shell
 ansible-specdoc -f jinja2 -t path/to/my/template.md.j2 -i path/to/my/module.py -o path/to/output/file.md
 ```
 
-Dynamically generating and injecting documentation back into module constants:
+---
+
+#### Dynamically generating and injecting documentation back into module constants:
 
 ```shell
 ansible-specdoc -j -i path/to/my/module.py
 ```
 
-Generating a raw documentation string (not recommended):
+NOTE: Documentation string injection requires that you have `DOCUMENTATION`, `RETURN`, and `EXAMPLES` constants defined in your module.
+
+---
+
+#### Generating a raw documentation string (not recommended):
 
 ```shell
 ansible-specdoc -f yaml -i path/to/my/module.py
@@ -45,7 +55,21 @@ ansible-specdoc -f yaml -i path/to/my/module.py
 
 ## Implementation
 
-### Module Metadata
+### Importing SpecDoc Classes
+
+All of the `ansible-specdoc` classes can be imported into an Ansible module using the following statement:
+
+```python
+from ansible_specdoc.objects import *
+```
+
+Alternatively, only specific classes can be imported using the following statement:
+
+```python
+from ansible_specdoc.objects import SpecDocMeta, SpecField, SpecReturnValue, FieldType
+```
+
+### Declaring Module Metadata
 The `ansible-specdoc` specification format requires that each module exports a `SPECDOC_META` object with the following structure:
 
 ```python
@@ -67,13 +91,10 @@ SPECDOC_META = SpecDocMeta(
 )
 ```
 
-### Argument Specification
+### Declaring Argument Specification
 
-Certain fields may automatically be passed into the Ansible-compatible spec dict.
-
-Spec fields may additional metadata that will appear in the documentation.
-
-For example:
+Each `SpecField` object translates to a parameter that can be rendered into documentation and passed into Ansible for specification.
+These fields should be declared in a dict format as shown below:
 
 ```python
 module_spec = {
@@ -85,7 +106,20 @@ module_spec = {
 }
 ```
 
+This dict should be passed into the `options` field of the `SPECDOC_META` declaration.
+
+### Passing Specification to Ansible
+
 In order to retrieve the Ansible-compatible spec dict, use the `SPECDOC_META.ansible_spec` property.
+
+### Other Notes
+
+To prevent `ansible-specdoc` from executing module code, please ensure that all module logic executes using the following pattern:
+
+```python
+if __name__ == '__main__':
+    main()
+```
 
 ## Templates
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ optional arguments:
                         The file to use as the template for templated formats.
 ```
 
+Generating a templated documentation file:
+
+```shell
+ansible-specdoc -f jinja2 -t path/to/my/template.md.j2 -i path/to/my/module.py -o path/to/output/file.md
+```
+
+Dynamically generating and injecting documentation back into module constants:
+
+```shell
+ansible-specdoc -j -i path/to/my/module.py
+```
+
+Generating a raw documentation string (not recommended):
+
+```shell
+ansible-specdoc -f yaml -i path/to/my/module.py
+```
+
 ## Specification Format
 
 ### Module Metadata
@@ -68,3 +86,7 @@ module_spec = {
 ```
 
 In order to retrieve the Ansible-compatible spec dict, use the `SPECDOC_META.ansible_spec` property.
+
+## Templates
+
+This repository provides an [example Markdown template](./template/module.md.j2) that can be used in conjunction with the `-t` argument.

--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -157,13 +157,13 @@ class CLI:
 
         to_inject = [['DOCUMENTATION', doc], ['RETURN', returns], ['EXAMPLES', examples]]
 
-        for v in to_inject:
-            doc_field = red.find('name', value=v[0])
+        for field_info in to_inject:
+            doc_field = red.find('name', value=field_info[0])
             if doc_field is None or doc_field.parent is None:
                 raise Exception('failed to inject documentation: '
-                                f'an empty {v[0]} field must be specified')
+                                f'an empty {field_info[0]} field must be specified')
 
-            doc_field.parent.value.value = f'\'\'\'\n{v[1]}\'\'\''
+            doc_field.parent.value.value = f'\'\'\'\n{field_info[1]}\'\'\''
 
         return red.dumps()
 
@@ -249,7 +249,7 @@ class CLI:
             return
 
         if self._args.output_format is not None:
-            self._parser.error(f'No format should be declared when using --inject.')
+            self._parser.error('No format should be declared when using --inject.')
 
         with open(self._args.input_file, 'r+') as file:
             injected_module = self._inject_docs(file.read())

--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -92,7 +92,8 @@ class SpecDocModule:
     def generate_ansible_doc_yaml(self) -> Tuple[str, str, str]:
         """Generates YAML documentation strings for all Ansible documentation fields."""
         documentation, returns, examples = self.__generate_ansible_doc_dicts()
-        return yaml.dump(documentation), yaml.dump(returns), yaml.dump(examples)
+
+        return yaml.dump(documentation), yaml.dump(returns), yaml.dump(examples, sort_keys=False)
 
     def generate_json(self) -> str:
         """Generates a JSON documentation string"""

--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -135,8 +135,8 @@ class CLI:
                                   help='The output format of the documentation.')
 
         self._parser.add_argument('-j', '--inject',
-                                  help='Inject the output documentation into the `DOCUMENTATION` '
-                                       'field of input module.',
+                                  help='Inject the output documentation into the `DOCUMENTATION`, '
+                                       '`RETURN`, and `EXAMPLES` fields of input module.',
                                   action='store_true')
 
         self._parser.add_argument('-t', '--template_file',

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -100,7 +100,6 @@ class SpecField:
 
         return result
 
-
     @property
     def ansible_spec(self) -> Dict[str, Any]:
         """
@@ -226,7 +225,8 @@ class SpecDocMeta:
 
         documentation = {
             'description': self.description,
-            'short_description': self.short_description if self.short_description is not None else self.description,
+            'short_description': self.short_description
+            if self.short_description is not None else self.description,
             'author': self.author,
             'deprecated': self.deprecated,
             'requirements': self.requirements,

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -35,8 +35,8 @@ class SpecField:
     A single field to be used in an Ansible module.
     """
     type: FieldType
-    description: Union[str, List[str]]
 
+    description: Union[str, List[str]] = ''
     version_added: Optional[str] = None
     required: bool = False
     default: Optional[Any] = None

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -124,7 +124,7 @@ class SpecField:
 
         if isinstance(result['description'], str):
             result['description'] = [result['description']]
-            
+
         if self.suboptions is not None:
             result['suboptions'] = {
                 k: v.doc_dict for k, v in self.suboptions.items() if not v.doc_hide

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -2,6 +2,8 @@
 This module contains various classes to be used in Ansible modules.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any, Tuple
 
@@ -47,7 +49,7 @@ class SpecField:
 
     # These fields are only necessary for `list` and `dict` types
     element_type: Optional[FieldType] = None
-    suboptions: Optional[Dict[str, 'SpecField']] = None  # Forward-declared
+    suboptions: Optional[Dict[str, SpecField]] = None  # Forward-declared
 
     # Additional fields to pass into the output Ansible spec dict
     additional_fields: Optional[Dict[str, Any]] = None
@@ -143,7 +145,7 @@ class SpecReturnValue:
     returned: str = 'always'
     version_added: Optional[str] = None
     sample: List[str] = field(default_factory=lambda: [])
-    contains: Optional[Dict[str, 'SpecReturnValue']] = None
+    contains: Optional[Dict[str, SpecReturnValue]] = None
     docs_url: Optional[str] = None
     elements: Optional[FieldType] = None
 

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -43,6 +43,10 @@ class DeprecationInfo:
 
     @property
     def ansible_doc_dict(self):
+        """
+        Returns a dict representing this deprecation.
+        """
+
         if self.removed_in and self.removed_by_date:
             raise ValueError('removed_in and removed_by_date are conflicting fields')
 

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -35,11 +35,12 @@ class DeprecationInfo:
     Contains info about a deprecated module.
     """
 
+    alternative: str
+
     removed_in: Optional[str] = None  # Mutually exclusive with removed_by_date
     removed_by_date: Optional[str] = None
 
     why: Optional[str] = None
-    alternative: Optional[str] = None
 
     @property
     def ansible_doc_dict(self):

--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -5,6 +5,8 @@ This module contains various classes to be used in Ansible modules.
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict, Any, Tuple
 
+import yaml
+
 
 class FieldType:
     """
@@ -237,7 +239,7 @@ class SpecDocMeta:
 
         return_values = {k: v.ansible_doc for k, v in self.return_values.items()}
 
-        examples = self.examples
+        examples = yaml.safe_load('\n'.join(self.examples))
 
         return documentation, return_values, examples
 

--- a/template/module.md.j2
+++ b/template/module.md.j2
@@ -1,0 +1,101 @@
+# {{ module }}
+
+{% if description %}
+{% for line in description %}
+{{ line }}
+
+{% endfor %}
+{% endif %}
+
+- [Examples](#examples)
+- [Parameters](#parameters)
+- [Return Values](#return-values)
+
+## Examples
+
+{% for example in examples %}```yaml{{ example }}
+```
+
+{% endfor %}
+
+{% set blocks = {} %}
+
+{% macro accumulate_blocks(opts) %}
+{% for name, spec in opts.items() %}{% if spec.suboptions %}{{ blocks.__setitem__(name, spec.suboptions) or '' }}{{ accumulate_blocks(spec.suboptions) or '' }}{% endif %}{% endfor %}
+{% endmacro %}
+
+{{ accumulate_blocks(options) }}
+
+{% macro options_display_req(opts, required) %}
+{% for name, spec in opts.items() %}
+{% if not spec.doc_hide and ((spec.required and required) or (not spec.required and not required)) %}
+{% set required_text = '**Required**' if spec.required else 'Optional' %}
+{% set type_text = '`%s`' % spec.type if spec.type else '' %}
+{% set name_fmt = '[`%s` (sub-options)](#%s)' % (name, name) if spec.suboptions else '`%s`' % name %}
+{% set extras_fmt = [] %}
+{% set choices_fmt = [] %}
+{% if spec.choices -%}
+{% for choice in spec.choices -%}
+{{ choices_fmt.append('`{}`'.format(choice|string)) or ''}}
+{%- endfor %}
+{{ extras_fmt.append("Choices: " + ', '.join(choices_fmt)) or '' }}
+{%- endif %}
+{% if spec.default or spec.default == False -%}
+{{ extras_fmt.append('Default: `{}`'.format(spec.default)) or ''}}
+{%- endif %}
+{% if spec.editable -%}
+{{ extras_fmt.append("Updatable") or '' }}
+{%- endif %}
+| {{ name_fmt }} | <center>{{type_text}}</center> | <center>{{ required_text }}</center> | {% for line in spec.description %}{{ line }} {% endfor %} {% if extras_fmt | length > 0 %}**({{ extras_fmt|join('; ') }})**{% endif %} |
+{% endif %}
+{% endfor %}
+{% endmacro %}
+
+{% macro options_display(opts) %}
+{{ options_display_req(opts, True) }}{{ options_display_req(opts, False) }}
+{% endmacro %}
+
+{% macro options_table(opts) %}
+| Field     | Type | Required | Description                                                                  |
+|-----------|------|----------|------------------------------------------------------------------------------|
+{{ options_display(opts) }}
+{% endmacro %}
+
+{% if options | length > 0 %}
+
+## Parameters
+
+{{ options_table(options) }}
+
+{% for name, spec in blocks.items() %}
+
+### {{ name }}
+
+{{ options_table(spec) }}
+
+{% endfor %}
+
+{% endif %}
+
+## Return Values
+
+{% for name, spec in return_values.items() %}
+- `{{ name }}`{% if spec.description %} - {% for line in spec.description %}{{ line }}{% endfor %}{% endif %}
+
+{% if spec.sample %}
+
+    - Sample Response:
+{% for sample in spec.sample %}
+        ```json
+{% for line in sample.split('\n') %}
+        {{ line }}
+{% endfor %}
+        ```
+{% endfor %}
+{% endif %}
+{% if spec.docs_url %}
+    - See the [API documentation]({{spec.docs_url}}) for a list of returned fields
+{% endif %}
+
+
+{% endfor %}

--- a/template/module.md.j2
+++ b/template/module.md.j2
@@ -84,7 +84,7 @@
 
 {% if spec.sample %}
 
-    - Sample Response:
+    - Sample Value:
 {% for sample in spec.sample %}
         ```json
 {% for line in sample.split('\n') %}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ class TestDocs(unittest.TestCase):
         assert generated_spec.get('requirements') == original_spec.requirements
         assert generated_spec.get('author') == original_spec.author
         assert generated_spec.get('examples') == original_spec.examples
+        assert generated_spec.get('deprecated') == original_spec.deprecated.ansible_doc_dict
         assert generated_spec.get('return_values') == {
             k: v.__dict__ for k, v in original_spec.return_values.items()
         }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,18 @@ class TestDocs(unittest.TestCase):
 
         self.assert_docs_dict_valid(module_1.SPECDOC_META, output_json)
 
+    def test_docs_file_ansible(self):
+        """Test that the JSON output is valid"""
+        module = SpecDocModule()
+
+        module.load_file(MODULE_1_DIR)
+
+        output_json = json.loads(module.generate_json())
+
+        assert output_json.get('module') == 'module_1'
+
+        self.assert_docs_dict_valid(module_1.SPECDOC_META, output_json)
+
     @staticmethod
     def test_docs_file_template():
         """Test that Jinja2 outputs are valid"""
@@ -115,11 +127,16 @@ class TestDocs(unittest.TestCase):
 
         module.load_file(module_path)
 
-        yaml_output = module.generate_yaml()
+        docs, returns, examples = module.generate_ansible_doc_yaml()
 
         with open(MODULE_1_DIR, 'r') as file:
             module_contents = file.read()
 
-        output = CLI._inject_docs(module_contents, yaml_output)
+        cli = CLI()
+        cli._mod = module
 
-        assert f'DOCUMENTATION = \'\'\'\n{yaml_output}\'\'\'' in output
+        output = cli._inject_docs(module_contents)
+
+        assert f'DOCUMENTATION = \'\'\'\n{docs}\'\'\'' in output
+        assert f'EXAMPLES = \'\'\'\n{examples}\'\'\'' in output
+        assert f'RETURN = \'\'\'\n{returns}\'\'\'' in output

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -1,6 +1,6 @@
 """Module for testing docs generation functionality"""
 
-from ansible_specdoc.objects import SpecDocMeta, SpecField, FieldType, SpecReturnValue
+from ansible_specdoc.objects import SpecDocMeta, SpecField, FieldType, SpecReturnValue, DeprecationInfo
 
 DOCUMENTATION = '''
 really cool non-empty docstring
@@ -69,6 +69,11 @@ SPECDOC_META = SpecDocMeta(
     examples=[
         'blah'
     ],
+    deprecated=DeprecationInfo(
+        why='cuz',
+        removed_in='1.0.0',
+        alternative='use something else'
+    ),
     return_values={
         'cool': SpecReturnValue(
             description='COOL',

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -1,6 +1,7 @@
 """Module for testing docs generation functionality"""
 
-from ansible_specdoc.objects import SpecDocMeta, SpecField, FieldType, SpecReturnValue, DeprecationInfo
+from ansible_specdoc.objects import SpecDocMeta, SpecField, FieldType, SpecReturnValue, \
+    DeprecationInfo
 
 DOCUMENTATION = '''
 really cool non-empty docstring

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -6,6 +6,13 @@ DOCUMENTATION = '''
 really cool non-empty docstring
 '''
 
+RETURN = '''
+really cool non-empty return string
+'''
+
+EXAMPLES = '''
+really cool non-empty examples'''
+
 MY_MODULE_DICT_SPEC = {
     'my-int': SpecField(
         type=FieldType.integer,


### PR DESCRIPTION
## 📝 Description

This pull request separates out the Ansible-compatible documentation generation/injection logic and adds support for injecting into the `RETURN` and `EXAMPLES` documentation constants.

Additionally, this pull request adds an example Markdown template to the `template` directory.

See https://github.com/linode/ansible_linode/issues/284

## ✔️ How to Test

```
make test
```