### PR TITLE
doc: Add link to `ansible-specdoc-example` repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A utility for dynamically generating documentation from an Ansible module's spec
 
 This project was primarily designed for the [Linode Ansible Collection](https://github.com/linode/ansible_linode).
 
+An example Ansible Collection using `ansible-specdoc` can be found [here](https://github.com/linode/ansible-specdoc-example).
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
## 📝 Description

This change adds a link to the [ansible-specdoc-example](https://github.com/linode/ansible-specdoc-example) repository, which serves as a starting point for people looking to use ansible-specdoc in their projects.
