### PR TITLE
Unpin dependency, update GitHub actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,13 +4,13 @@ on: [ push, pull_request ]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+        uses: actions/checkout@v3
 
       - name: setup python 3
-        uses: actions/setup-python@0291cefc54fa79cd1986aee8fa5ecb89ad4defea # pin@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4 # pin@v5
+      - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # pin@v5.23.0
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+        uses: actions/checkout@v3
 
       - name: update packages
         run: sudo apt-get update -y
@@ -17,7 +17,7 @@ jobs:
         run: sudo apt-get install -y build-essential
 
       - name: setup python 3
-        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # pin@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
@@ -27,6 +27,6 @@ jobs:
           SPECDOC_VERSION: ${{ github.event.release.tag_name }}
 
       - name: publish the release to pypi
-        uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f # pin@release/v1
+        uses: pypa/gh-action-pypi-publish@a56da0b891b3dc519c7ee3284aff1fad93cc8598 # pin@v1.8.6
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,13 +4,13 @@ on: [ push, pull_request ]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@f1d3225b5376a0791fdee5a0e8eac5289355e43a # pin@v2
+        uses: actions/checkout@v3
 
       - name: setup python 3
-        uses: actions/setup-python@0291cefc54fa79cd1986aee8fa5ecb89ad4defea # pin@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
 [MASTER]
 
 [MESSAGES CONTROL]
-disable=exec-used, too-many-branches, too-few-public-methods, unspecified-encoding, consider-using-f-string, too-many-instance-attributes
+disable=exec-used, too-many-branches, too-few-public-methods, unspecified-encoding, consider-using-f-string, too-many-instance-attributes, broad-exception-raised

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-pytest==6.2.4
-pylint==2.15.5
-build==0.4.0
+pytest>=6.2.4
+pylint>=2.15.5
+build>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyYAML==5.4.1
-Jinja2==3.0.1
-redbaron==0.9.2
+PyYAML>=5.4.1
+Jinja2>=3.0.1
+redbaron>=0.9.2


### PR DESCRIPTION
## 📝 Description

Update GitHub actions to ensure the workflow is not broken after the deprecated functionalities removal.

Unpin the dependency versiona to allow users to use the latest versions of them.
