### PR TITLE
Zhiwei/setup update

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: run linter
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: '3.x'
 
       - name: install dependencies
-        run: pip3 install -r requirements-dev.txt -r requirements.txt
+        run: make deps
 
       - name: run tests
         run: make test

--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,12 @@ deps:
 	pip install -r requirements-dev.txt -r requirements.txt
 
 build: deps
-	python setup.py build && python -m build
+	python -m build --sdist --wheel
 
 install: clean_dist build
 	pip3 install --force dist/*.whl
 
 clean_dist:
-	python setup.py clean --dist
+	rm -rf dist ansible_specdoc.egg-info build
 
 .PHONY: lint test build

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest>=7.0.0
 pylint>=2.15.5
-build>=0.4.0
+build>=0.10.0
 black>=23.1.0
 isort>=5.12.0
 autoflake>=2.0.1

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,13 @@ def get_version():
     # Default unspecified version
     return "0.0.0"
 
+def read_requirements():
+    with open('requirements.txt', 'r') as req:
+        content = req.read()
+        requirements = content.split('\n')
+
+    return requirements
+
 setuptools.setup(
     name="ansible-specdoc",
     version=get_version(),
@@ -31,15 +38,9 @@ setuptools.setup(
     keywords="ansible",
     url="https://github.com/linode/ansible-specdoc/",
     packages=['ansible_specdoc'],
-    install_requires=[
-        'PyYAML==5.4.1',
-        'Jinja2==3.0.1',
-        'redbaron==0.9.2'
-    ],
-    setup_requires=['setupext_janitor'],
+    install_requires=read_requirements(),
     python_requires='>=3',
     entry_points={
         'console_scripts': ['ansible-specdoc=ansible_specdoc.cli:main'],
-        'distutils.commands': ['clean = setupext_janitor.janitor:CleanCommand']
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 import os
+from pathlib import Path
 
 import setuptools
 
-here = os.path.abspath(os.path.dirname(__file__))
+readme_path = Path(__file__).resolve() / "README.md"
 
 def get_long_description():
-    with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+    with open(readme_path, encoding="utf-8") as f:
         long_description = f.read()
 
     return long_description
@@ -20,9 +21,9 @@ def get_version():
     return "0.0.0"
 
 def read_requirements():
-    with open('requirements.txt', 'r') as req:
+    with open("requirements.txt", "r") as req:
         content = req.read()
-        requirements = content.split('\n')
+        requirements = content.split("\n")
 
     return requirements
 
@@ -37,10 +38,10 @@ setuptools.setup(
     license="Apache License 2.0",
     keywords="ansible",
     url="https://github.com/linode/ansible-specdoc/",
-    packages=['ansible_specdoc'],
+    packages=["ansible_specdoc"],
     install_requires=read_requirements(),
-    python_requires='>=3',
+    python_requires=">=3",
     entry_points={
-        'console_scripts': ['ansible-specdoc=ansible_specdoc.cli:main'],
-    }
+        "console_scripts": ["ansible-specdoc=ansible_specdoc.cli:main"],
+    },
 )


### PR DESCRIPTION
## 📝 Description

1. `python setup.py build` is deprecated. `python -m build` is the new build frontend for Python projects.
2. `setupext_janitor` lacks maintenance.

## ✔️ How to Test

Install and test it with ansible repo's `make gendocs`