### PR TITLE
Change injection to use rich text blocks

### DIFF
--- a/ansible_specdoc/cli.py
+++ b/ansible_specdoc/cli.py
@@ -223,7 +223,7 @@ class CLI:
                     f"an empty {field_info[0]} field must be specified"
                 )
 
-            doc_field.parent.value.value = f"'''\n{field_info[1]}'''"
+            doc_field.parent.value.value = f'r"""\n{field_info[1]}"""'
 
         return red.dumps()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,9 +160,9 @@ class TestDocs(unittest.TestCase):
 
         output = cli._inject_docs(module_contents)
 
-        assert f"DOCUMENTATION = '''\n{docs}'''" in output
-        assert f"EXAMPLES = '''\n{examples}'''" in output
-        assert f"RETURN = '''\n{returns}'''" in output
+        assert f'DOCUMENTATION = r"""\n{docs}"""' in output
+        assert f'EXAMPLES = r"""\n{examples}"""' in output
+        assert f'RETURN = r"""\n{returns}"""' in output
 
     @staticmethod
     def test_docs_file_clear():
@@ -183,6 +183,6 @@ class TestDocs(unittest.TestCase):
 
         output = cli._inject_docs(module_contents)
 
-        assert "DOCUMENTATION = '''\n'''" in output
-        assert "EXAMPLES = '''\n'''" in output
-        assert "RETURN = '''\n'''" in output
+        assert f'DOCUMENTATION = r"""\n"""' in output
+        assert f'EXAMPLES = r"""\n"""' in output
+        assert f'RETURN = r"""\n"""' in output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,6 +183,6 @@ class TestDocs(unittest.TestCase):
 
         output = cli._inject_docs(module_contents)
 
-        assert f'DOCUMENTATION = r"""\n"""' in output
-        assert f'EXAMPLES = r"""\n"""' in output
-        assert f'RETURN = r"""\n"""' in output
+        assert 'DOCUMENTATION = r"""\n"""' in output
+        assert 'EXAMPLES = r"""\n"""' in output
+        assert 'RETURN = r"""\n"""' in output

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -8,15 +8,15 @@ from ansible_specdoc.objects import (
     SpecReturnValue,
 )
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 really cool non-empty docstring
 """
 
-RETURN = """
+RETURN = r"""
 really cool non-empty return string
 """
 
-EXAMPLES = """
+EXAMPLES = r"""
 really cool non-empty examples"""
 
 MY_MODULE_DICT_SPEC = {


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

While working on ansible_linode injection I found the fields need to use `r"""` rich text.

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

```bash
make test
```
