### PR TITLE
update returns to render as yaml

### DIFF
--- a/ansible_specdoc/objects.py
+++ b/ansible_specdoc/objects.py
@@ -5,6 +5,7 @@ This module contains various classes to be used in Ansible modules.
 from __future__ import annotations
 
 import copy
+import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -213,7 +214,7 @@ class SpecReturnValue:
             "description": self.description,
             "type": str(self.type),
             "returned": self.returned,
-            "sample": self.sample,
+            "sample": json.loads("".join(self.sample)),
         }
 
         if self.elements is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,6 +163,7 @@ class TestDocs(unittest.TestCase):
         assert f'DOCUMENTATION = r"""\n{docs}"""' in output
         assert f'EXAMPLES = r"""\n{examples}"""' in output
         assert f'RETURN = r"""\n{returns}"""' in output
+        assert '{' not in returns
 
     @staticmethod
     def test_docs_file_clear():


### PR DESCRIPTION
## 📝 Description

**What does this PR do and why is this change necessary?**

Replaces the existing return samples with a yaml style format which will render correctly on Galaxy.

## ✔️ How to Test

**How do I run the relevant unit/integration tests?**

```bash
make test
```

1. Install the tool
```bash
make install
```
2. Go to ansible_linode and use it on a module
```bash
ansible-specdoc -j -i plugins/modules/domain.py
```
3. Open and view the file verfiying the format of the `RETURN` section
