### PR TITLE
Require Python 3.9 and remove 3.8 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,22 @@
 [tool.pylint.main]
-py-version = "3.8"
-disable = ["raw-checker-failed", "bad-inline-option", "locally-disabled", "file-ignored", "suppressed-message", "useless-suppression", "deprecated-pragma", "use-symbolic-message-instead", "exec-used", "too-many-branches", "too-few-public-methods", "unspecified-encoding", "consider-using-f-string", "too-many-instance-attributes", "broad-exception-raised"]
+py-version = "3.9"
+disable = [
+    "raw-checker-failed",
+    "bad-inline-option",
+    "locally-disabled",
+    "file-ignored",
+    "suppressed-message",
+    "useless-suppression",
+    "deprecated-pragma",
+    "use-symbolic-message-instead",
+    "exec-used",
+    "too-many-branches",
+    "too-few-public-methods",
+    "unspecified-encoding",
+    "consider-using-f-string",
+    "too-many-instance-attributes",
+    "broad-exception-raised",
+]
 
 [build-system]
 requires = ["setuptools", "wheel"]
@@ -12,7 +28,7 @@ line_length = 80
 
 [tool.black]
 line-length = 80
-target-version = ["py38", "py39", "py310", "py311"]
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.autoflake]
 expand-star-imports = false

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     url="https://github.com/linode/ansible-specdoc/",
     packages=["ansible_specdoc"],
     install_requires=requirements_path.read_text().splitlines(),
-    python_requires=">=3",
+    python_requires=">=3.9",
     entry_points={
         "console_scripts": ["ansible-specdoc=ansible_specdoc.cli:main"],
     },

--- a/tests/test_modules/module_1.py
+++ b/tests/test_modules/module_1.py
@@ -60,7 +60,7 @@ MY_MODULE_SPEC = {
 
 SPECDOC_META = SpecDocMeta(
     description=["My really cool Ansible module!"],
-    requirements=["python >= 3.8"],
+    requirements=["python >= 3.9"],
     author=["Lena Garber"],
     examples=["blah"],
     deprecated=DeprecationInfo(


### PR DESCRIPTION
## 📝 Description
Python 3.8 has been EOL so we can remove the support for it.